### PR TITLE
Looking for text in a page does not directly access html source

### DIFF
--- a/salad/steps/browser/elements.py
+++ b/salad/steps/browser/elements.py
@@ -8,7 +8,7 @@ from splinter.exceptions import ElementDoesNotExist
 
 @step(r'should( not)? see "(.*)" (?:somewhere|anywhere) in (?:the|this) page')
 def should_see_in_the_page(step, negate, text):
-    assert_with_negate(text in world.browser.html, negate)
+    assert_with_negate(world.browser.is_text_present(text), negate)
 
 
 @step(r'should( not)? see a link (?:called|with the text) "(.*)"')


### PR DESCRIPTION
Splinter allows you to set a `wait_time` that wraps several functions to allow polling during slow page loads. There is also `browser.driver.implicitly_wait` which does similarly. Unfortunately looking directly at the browser.html property bypasses both these methods. Using this function at least respsect `wait_time` though I don't know about `implicitly_wait`
