### PR TITLE
Use Travis for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  #- "3.2" # Fails miserably in Python 3
+install:
+  - "python setup.py test"
+  - "easy_install *.egg"
+  # Firefox is already installed
+  # Install Google Chrome
+  - "wget https://dl.google.com/linux/direct/google-chrome-stable_current_i386.deb"
+  - "sudo apt-get install libgconf2-4"
+  - "sudo dpkg -i google-chrome*.deb"
+  - "sudo apt-get -f install" # reported dependency issue?
+  # Install the Google Chrome webdriver
+  - "mkdir /tmp/bin"
+  - "wget https://chromedriver.googlecode.com/files/chromedriver_linux32_23.0.1240.0.zip"
+  - "unzip chromedriver_linux32_23.0.1240.0.zip"
+  - "mv chromedriver /tmp/bin"
+before_script:
+  # Setup headless X per http://about.travis-ci.org/docs/user/gui-and-headless-browsers/
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+script: "PATH=$PATH:/tmp/bin lettuce salad --verbosity=2"


### PR DESCRIPTION
This shit is seriously awesome:
Step 1) Go to http://travis-ci.org and sign up
Step 2) Go to your Travis CI profile and click the 'on' button for w+k/salad
Step 3) Merge this PR
Step 4) Bask in automated executions of your tests against Linux Firefox + Chrome, both for master _and_ all pull requests.

I've tested this on my own branch in http://travis-ci.org/#!/medwards/salad/jobs/2446727

This tests python 2.6 and 2.7. python 3.2 can't even make it out of the setup stage right now so its commented out.

Verbosity might be a bit high. I'm thinking about tuning it down, but for now it should be fine.
