### PR TITLE
Specify browser on the command-line, not in features.

### DIFF
--- a/salad/cli.py
+++ b/salad/cli.py
@@ -1,11 +1,37 @@
 import sys
+import argparse
 
 from lettuce.bin import main as lettuce_main
 
+BROWSER_CHOICES = ["firefox", "chrome", "zope"]
+DEFAULT_BROWSER = BROWSER_CHOICES[:1]
+
+
+class CommaSeparatedBrowserAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        browsers = namespace.browsers
+        for v in values.split(","):
+            if v in BROWSER_CHOICES:
+                if not v in browsers:
+                    browsers.append(v)
+            else:
+                raise argparse.ArgumentTypeError("Unknown browser '%s'" % v)
+        setattr(namespace, 'browsers', browsers)
+
 
 def main(args=sys.argv[1:]):
-    # Right now, this doesn't do anything but alias.  More useful is coming though!
-    lettuce_main(args=sys.argv[1:])
+    parser = argparse.ArgumentParser(prog="Salad", description='BDD browswer-automation made tasty.')
+
+    parser.add_argument('--browsers', default=DEFAULT_BROWSER,
+                     action=CommaSeparatedBrowserAction,
+                     help="""Comma-separated list of browsers to use. Default is %s. Options:
+                             firefox\n
+                             chrome\n
+                             zope""" % DEFAULT_BROWSER[0])
+    parser.add_argument('args', nargs=argparse.REMAINDER)
+
+    parsed_args = parser.parse_args()
+    lettuce_main(args=parsed_args.args)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
We should be specifying what browsers we want to use when we run the salad command, not in the features themselves.  So, instead of doing this:

``` gherkin
Given I am using <browser>
  And I am sane
When I do foo
Then I should see bar

Examples:
    | browser   |
    | chrome    |
    | firefox   |
```

and

``` bash
~ $ salad
```

We should do something like:

``` gherkin
Given I am sane
When I do foo
Then I should see bar
```

and on the command-line:

``` bash
~ $ salad --browsers=chrome,firefox
```

(Convo pulled from pull #13)
