### PR TITLE
.gitignore is more comprehensive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,42 @@
-*.pyc
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Mac OSX
 .DS_Store
-salad.egg-info
-salad.egg-info/*
-dist/*
-salad/chromedriver.log
+
+# Chromedriver
+chromedriver.log
+chromedriver


### PR DESCRIPTION
`python setup.py install` leaves my salad folder a mess, this is slightly nicer.
