### PR TITLE
_get_element signature is simpler

### DIFF
--- a/salad/steps/browser/elements.py
+++ b/salad/steps/browser/elements.py
@@ -1,5 +1,6 @@
 from lettuce import step, world
 from salad.tests.util import assert_equals_with_negate, assert_with_negate, parsed_negator
+from salad.steps.parsers import pick_to_index
 from salad.steps.browser.finders import ELEMENT_FINDERS, ELEMENT_THING_STRING, _get_element
 from splinter.exceptions import ElementDoesNotExist
 
@@ -20,12 +21,14 @@ def should_see_a_link_called(step, negate, text):
 def should_see_a_link_to(step, negate, link):
     assert_with_negate(len(world.browser.find_link_by_href(link)) > 0, negate)
 
+
 for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     def _visible_generator(finder_string, finder_function):
-        @step(r'should( not)? see (?:the|a|an)( first)?( last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, negate, first, last, find_pattern):
+        @step(r'should( not)? see (?:the|a|an)( first| last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, negate, pick, find_pattern):
             try:
-                _get_element(finder_function, first, last, find_pattern, expect_not_to_find=True)
+                pick = pick_to_index(pick)
+                _get_element(finder_function, pick, find_pattern, expect_not_to_find=True)
             except ElementDoesNotExist:
                 assert parsed_negator(negate)
 
@@ -34,9 +37,10 @@ for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     globals()["form_visible_%s" % (finder_function,)] = _visible_generator(finder_string, finder_function)
 
     def _contains_generator(finder_string, finder_function):
-        @step(r'should( not)? see that the( first)?( last)? %s %s contains? "(.*)"' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, negate, first, last, find_pattern, content):
-            ele = _get_element(finder_function, first, last, find_pattern)
+        @step(r'should( not)? see that the( first| last)? %s %s contains? "(.*)"' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, negate, pick, find_pattern, content):
+            pick = pick_to_index(pick)
+            ele = _get_element(finder_function, pick, find_pattern)
             assert_with_negate(content in ele.text, negate)
 
         return _this_step
@@ -44,9 +48,10 @@ for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     globals()["form_contains_%s" % (finder_function,)] = _contains_generator(finder_string, finder_function)
 
     def _is_exactly_generator(finder_string, finder_function):
-        @step(r'should( not)? see that the( first)?( last)? %s %s (?:is|contains) exactly "(.*)"' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, negate, first, last, find_pattern, content):
-            ele = _get_element(finder_function, first, last, find_pattern)
+        @step(r'should( not)? see that the( first| last)? %s %s (?:is|contains) exactly "(.*)"' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, negate, pick, find_pattern, content):
+            pick = pick_to_index(pick)
+            ele = _get_element(finder_function, pick, find_pattern)
             assert_equals_with_negate(ele.text, content, negate)
 
         return _this_step
@@ -54,9 +59,10 @@ for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     globals()["form_exactly_%s" % (finder_function,)] = _is_exactly_generator(finder_string, finder_function)
 
     def _attribute_value_generator(finder_string, finder_function):
-        @step(r'should( not)? see that the( first)?( last)? %s %s has (?:an|the) attribute (?:of|named|called) "(.*)" with(?: the)? value "(.*)"' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, negate, first, last, find_pattern, attr_name, attr_value):
-            ele = _get_element(finder_function, first, last, find_pattern)
+        @step(r'should( not)? see that the( first| last)? %s %s has (?:an|the) attribute (?:of|named|called) "(.*)" with(?: the)? value "(.*)"' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, negate, pick, find_pattern, attr_name, attr_value):
+            pick = pick_to_index(pick)
+            ele = _get_element(finder_function, pick, find_pattern)
             assert_equals_with_negate("%s" % ele[attr_name], attr_value, negate)
 
         return _this_step
@@ -64,9 +70,10 @@ for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     globals()["form_attribute_value_%s" % (finder_function,)] = _attribute_value_generator(finder_string, finder_function)
 
     def _attribute_generator(finder_string, finder_function):
-        @step(r'should( not)? see that the( first)?( last)? %s %s has (?:an|the) attribute (?:of|named|called) "(\w*)"$' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, negate, first, last, find_pattern, attr_name):
-            ele = _get_element(finder_function, first, last, find_pattern)
+        @step(r'should( not)? see that the( first| last)? %s %s has (?:an|the) attribute (?:of|named|called) "(\w*)"$' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, negate, pick, find_pattern, attr_name):
+            pick = pick_to_index(pick)
+            ele = _get_element(finder_function, pick, find_pattern)
             assert_with_negate(ele[attr_name] != None, negate)
 
         return _this_step

--- a/salad/steps/browser/finders.py
+++ b/salad/steps/browser/finders.py
@@ -1,5 +1,6 @@
 from lettuce import world
 from salad.logger import logger
+from salad.steps.parsers import pick_to_index
 from splinter.exceptions import ElementDoesNotExist
 
 ELEMENT_FINDERS = {
@@ -20,15 +21,13 @@ ELEMENT_THING_STRING = "(?:element|thing|field|textarea|radio button|button|chec
 LINK_THING_STRING = "link"
 
 
-def _get_element(finder_function, first, last, pattern, expect_not_to_find=False, leave_in_list=False):
+def _get_element(finder_function, pick, pattern, expect_not_to_find=False, leave_in_list=False):
 
     ele = world.browser.__getattribute__(finder_function)(pattern)
 
     try:
-        if first:
-            ele = ele.first
-        if last:
-            ele = ele.last
+        index = pick_to_index(pick)
+        ele = ele[index]
 
         if not "WebDriverElement" in "%s" % type(ele):
             if len(ele) > 1:

--- a/salad/steps/browser/forms.py
+++ b/salad/steps/browser/forms.py
@@ -10,9 +10,9 @@ from salad.tests.util import assert_equals_with_negate
 for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
 
     def _fill_generator(finder_string, finder_function):
-        @step(r'fill in the( first)?( last)? %s %s with "(.*)"' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, first, last, find_pattern, text):
-            ele = _get_element(finder_function, first, last, find_pattern)
+        @step(r'fill in the( first| last)? %s %s with "(.*)"' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, pick, find_pattern, text):
+            ele = _get_element(finder_function, pick, find_pattern)
             try:
                 ele.value = text
             except:
@@ -39,9 +39,9 @@ for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     globals()["form_type_%s" % (finder_function,)] = _type_generator(finder_string, finder_function)
 
     def _attach_generator(finder_string, finder_function):
-        @step(r'attach "(.*)" onto the( first)?( last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, file_name, first, last, find_pattern):
-            ele = _get_element(finder_function, first, last, find_pattern)
+        @step(r'attach "(.*)" onto the( first| last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, file_name, pick, find_pattern):
+            ele = _get_element(finder_function, pick, find_pattern)
             try:
                 ele.value = file_name
             except:  # Zope
@@ -69,9 +69,9 @@ for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     globals()["form_select_%s" % (finder_function,)] = _select_generator(finder_string, finder_function)
 
     def _focus_generator(finder_string, finder_function):
-        @step(r'focus on the( first)?( last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, first, last, find_pattern):
-            ele = _get_element(finder_function, first, last, find_pattern)
+        @step(r'focus on the( first| last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, pick, find_pattern):
+            ele = _get_element(finder_function, pick, find_pattern)
             ele.focus()
 
         return _this_step
@@ -79,9 +79,9 @@ for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     globals()["form_focus_%s" % (finder_function,)] = _focus_generator(finder_string, finder_function)
 
     def _blur_generator(finder_string, finder_function):
-        @step(r'(?:blur|move) from the( first)?( last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, first, last, find_pattern):
-            ele = _get_element(finder_function, first, last, find_pattern)
+        @step(r'(?:blur|move) from the( first| last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, pick, find_pattern):
+            ele = _get_element(finder_function, pick, find_pattern)
             ele.blur()
 
         return _this_step
@@ -89,9 +89,9 @@ for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     globals()["form_blur_%s" % (finder_function,)] = _blur_generator(finder_string, finder_function)
 
     def _value_generator(finder_string, finder_function):
-        @step(r'(?:should see that the)? value of the( first)?( last)? %s %s is( not)? "(.*)"' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, first, last, find_pattern, negate, value):
-            ele = _get_element(finder_function, first, last, find_pattern)
+        @step(r'(?:should see that the)? value of the( first| last)? %s %s is( not)? "(.*)"' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, pick, find_pattern, negate, value):
+            ele = _get_element(finder_function, pick, find_pattern)
             assert_equals_with_negate(ele.value, value, negate)
 
         return _this_step
@@ -99,10 +99,10 @@ for finder_string, finder_function in ELEMENT_FINDERS.iteritems():
     globals()["form_value_%s" % (finder_function,)] = _value_generator(finder_string, finder_function)
 
     def _key_generator(finder_string, finder_function):
-        @step(r'hit the (.*) key in the ( first)?( last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
-        def _this_step(step, first, last, find_pattern):
+        @step(r'hit the (.*) key in the ( first| last)? %s %s' % (ELEMENT_THING_STRING, finder_string))
+        def _this_step(step, pick, find_pattern):
             key = transform_key_string(key_string)
-            ele = _get_element(finder_function, first, last, find_pattern)
+            ele = _get_element(finder_function, pick, find_pattern)
             ele.type(key)
 
         return _this_step

--- a/salad/steps/browser/mouse.py
+++ b/salad/steps/browser/mouse.py
@@ -45,9 +45,9 @@ actions = {
 
 def step_generator(action_string, action_function, thing_string, finder_string, finder_function):
 
-    @step(r'%s (?:a|the)( first)?( last)? %s %s' % (action_string, thing_string, finder_string))
-    def _this_step(step, first, last, find_pattern):
-        ele = _get_element(finder_function, first, last, find_pattern)
+    @step(r'%s (?:a|the)( first| last)? %s %s' % (action_string, thing_string, finder_string))
+    def _this_step(step, pick, find_pattern):
+        ele = _get_element(finder_function, pick, find_pattern)
 
         ele.__getattribute__(action_function)()
 
@@ -56,10 +56,10 @@ def step_generator(action_string, action_function, thing_string, finder_string, 
 
 def drag_and_drop_generator(thing_string, finder_string, finder_function):
 
-    @step(r'drag the( first)?( last)? %s %s and drop it on the( first)?( last)? %s %s' % (thing_string, finder_string, thing_string, finder_string))
-    def _this_step(step, first_hander, last_handler, drag_handler_pattern, first_target, last_target, drag_target_pattern):
-        handler = _get_element(finder_function, first_hander, last_handler, drag_handler_pattern)
-        target = _get_element(finder_function, first_target, last_target, drag_target_pattern)
+    @step(r'drag the( first| last)? %s %s and drop it on the( first| last)? %s %s' % (thing_string, finder_string, thing_string, finder_string))
+    def _this_step(step, handler_pick, drag_handler_pattern, target_pick, drag_target_pattern):
+        handler = _get_element(finder_function, handler_pick, drag_handler_pattern)
+        target = _get_element(finder_function, target_pick, drag_target_pattern)
 
         handler.drag_and_drop(target)
 

--- a/salad/steps/parsers.py
+++ b/salad/steps/parsers.py
@@ -1,0 +1,8 @@
+def pick_to_index(pick_string):
+    pick_string = pick_string or 'first'
+    pick = pick_string.lower().strip()
+    if pick == "first":
+        return 0
+    elif pick == "last":
+        return -1
+    return int(pick.strip('st nd th')) - 1  # strip 'th' or 'rd off


### PR DESCRIPTION
Its a big blob but the change is pretty simple:

I didn't like all the 'first, last' things kicking around so I made `pick_to_index` which can parse the `( first| last)?` regex group into an array index. `pick_to_index` is future-proofed to support '1st, 2nd, 3rd, 4th' and so on, but I didn't put it in yet (I'm bad at regex).

Some things I don't like:
-  `pick_to_index` returns 0 when it receives `None` (although now that its encapsulated in `_get_element` maybe I can move the logic there)
-  I want to just pass a raw index to `_get_element` but it gets really gross because that means every step generator has a call to `pick_to_index` which seemed like too much burden so I just pushed it down
-  `_convert_to_css` hasn't been converted to this, partly because there is no `second-child` selector nor did it ever default to `first` like `_get_element` but also because I'm worried that the first and last selectors might be be incorrectly implemented here (I could only find references to `first-child` and `last-child` online for example)

Anyways, I like the step method definitions and `_get_element`'s definition a lot more now. Let me know what you think!
