### PR TITLE
Browser versions

### DIFF
--- a/salad/cli.py
+++ b/salad/cli.py
@@ -12,12 +12,27 @@ BROWSER_CHOICES.append('zope.testbrowser')
 BROWSER_CHOICES.sort()
 DEFAULT_BROWSER = 'firefox'
 
+class store_driver_and_version(argparse.Action):
+    drivers = BROWSER_CHOICES
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        driver_info = values.split('-')
+        if driver_info[0] not in self.drivers:
+            args = {'driver': driver_info[0],
+                    'choices': ', '.join(map(repr, self.drivers))}
+            message = 'invalid choice: %(driver)r (choose from %(choices)s)'
+            raise argparse.ArgumentError(self, message % args)
+        setattr(namespace, self.dest, driver_info[0])
+        if len(driver_info) > 1:
+            setattr(namespace, 'version', driver_info[1])
+        if len(driver_info) > 2:
+            setattr(namespace, 'platform', driver_info[2].replace('_', ' '))
 
 def main(args=sys.argv[1:]):
     parser = argparse.ArgumentParser(prog="Salad", description='BDD browswer-automation made tasty.')
 
     parser.add_argument('--browser', default=DEFAULT_BROWSER,
-                        metavar='BROWSER', choices=BROWSER_CHOICES,
+                        action=store_driver_and_version, metavar='BROWSER',
                         help=('Browser to use. Options: %s Default is %s.' %
                               (BROWSER_CHOICES, DEFAULT_BROWSER)))
     parser.add_argument('--remote-url',
@@ -26,6 +41,11 @@ def main(args=sys.argv[1:]):
     (parsed_args, leftovers) = parser.parse_known_args()
     world.drivers = [parsed_args.browser]
     world.remote_url = parsed_args.remote_url
+    world.remote_capabilities = {}
+    if 'version' in parsed_args:
+        world.remote_capabilities['version'] = parsed_args.version
+    if 'platform' in parsed_args:
+        world.remote_capabilities['platform'] = parsed_args.platform
     lettuce_main(args=leftovers)
 
 if __name__ == '__main__':

--- a/salad/terrains/browser.py
+++ b/salad/terrains/browser.py
@@ -12,16 +12,18 @@ def setup_master_browser():
         browser = 'firefox'
         remote_url = None
 
-    world.master_browser = setup_browser(browser, remote_url)
+    capabilities = world.remote_capabilities
+    world.master_browser = setup_browser(browser, remote_url, **capabilities)
     world.browser = world.master_browser
 
 
-def setup_browser(browser, url=None):
+def setup_browser(browser, url=None, **capabilities):
     logger.info("Setting up browser %s..." % browser)
     try:
         if url:
+            logger.warn(capabilities)
             browser = Browser('remote', url=url,
-                    browser=browser)
+                    browser=browser, **capabilities)
         else:
             browser = Browser(browser)
     except Exception as e:


### PR DESCRIPTION
Its not the prettiest, but it allows users to specify platform and version when using a remote-url, so

`salad --browser firefox-15-Windows_2012 --remote-url http://somegridprovider/wd/hub salad/features`

Will launch a Firefox 15 instance (the default is 18) on Windows 8 (the default is XP aka Windows 2003) if your grid provider has it available.

You _might_ need bleeding edge splinter for this to work. I caught a bug in my initial remote-driver implementation but fortunately it looks like someone fixed it recently.
